### PR TITLE
Correct case on 'host' key in headers array

### DIFF
--- a/src/Middleware/AwsSignatureMiddleware.php
+++ b/src/Middleware/AwsSignatureMiddleware.php
@@ -40,11 +40,18 @@ class AwsSignatureMiddleware
     {
         return function ($request)  use ($handler) {
             $headers = $request['headers'];
-            if ($headers['Host']) {
-                if (is_array($headers['Host'])) {
-                    $headers['Host'] = array_map([$this, 'removePort'], $headers['Host']);
+            $host = null;
+            if (isset($headers['host'])) {
+                $host = $headers['host'];
+            } elseif (isset($headers['Host'])) {
+                $host = $headers['Host'];
+            }
+
+            if ($host) {
+                if (is_array($host)) {
+                    $headers['Host'] = array_map([$this, 'removePort'], $host);
                 } else {
-                    $headers['Host'] = $this->removePort($headers['Host']);
+                    $headers['Host'] = $this->removePort($host);
                 }
             }
             $psrRequest = new Request($request['http_method'], $request['uri'], $headers, $request['body']);

--- a/src/Middleware/AwsSignatureMiddleware.php
+++ b/src/Middleware/AwsSignatureMiddleware.php
@@ -40,11 +40,11 @@ class AwsSignatureMiddleware
     {
         return function ($request)  use ($handler) {
             $headers = $request['headers'];
-            if ($headers['host']) {
-                if (is_array($headers['host'])) {
-                    $headers['host'] = array_map([$this, 'removePort'], $headers['host']);
+            if ($headers['Host']) {
+                if (is_array($headers['Host'])) {
+                    $headers['Host'] = array_map([$this, 'removePort'], $headers['Host']);
                 } else {
-                    $headers['host'] = $this->removePort($headers['host']);
+                    $headers['Host'] = $this->removePort($headers['Host']);
                 }
             }
             $psrRequest = new Request($request['http_method'], $request['uri'], $headers, $request['body']);


### PR DESCRIPTION
$request['headers'] in the elasticsearch-php sdk now looks like:

```
[
	'Host' => ['example.com'],
	'Content-Type' => ['application/json'],
]
```

This commit is where the breaking change occurred: https://github.com/elastic/elasticsearch-php/commit/045aac44f63522b3826c514a690c45d8cae499ca
