### PR TITLE
Bugfix, URLs being parsed as path and not host

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require": {
+        "php": "^7.1",
         "aws/aws-sdk-php": "^3.8"
     },
     "autoload": {

--- a/src/Middleware/AwsSignatureMiddleware.php
+++ b/src/Middleware/AwsSignatureMiddleware.php
@@ -72,7 +72,8 @@ class AwsSignatureMiddleware
      */
     protected function removePort($host)
     {
-        return parse_url($host)['host'];
+        $parsedHost = parse_url($host);
+        return $parsedHost['host'] ?? $parsedHost['path'];
     }
 
 }


### PR DESCRIPTION
We are using Elasticsearch on AWS and creating our `Client` using this class:

```php
class ElasticSearchClientFactory
{

    /** @var ElasticsearchConfigInterface */
    private $elasticsearchConfig;

    /** @var LoggerInterface */
    private $logger;
    
    /** @var SignatureInterface */
    private $awsSigner;
    
    /** @var CredentialProvider */
    private $awsCredentialProvider;
    
    public function __construct(
        ElasticsearchConfigInterface $elasticsearchConfig,
        ?LoggerInterface $logger = null,
        ?SignatureInterface $awsSigner = null,
        ?callable $awsCredentialProvider = null
    ) {
        $this->elasticsearchConfig = $elasticsearchConfig;
        $this->logger = $logger ?? new NullLogger();
        $this->awsSigner = $awsSigner ?? new SignatureV4("es", "eu-central-1");
        $this->awsCredentialProvider = $awsCredentialProvider ?? CredentialProvider::defaultProvider();
    }

    /**
     * Create a new client for Elastic Search
     *
     * @return Client
     */
    public function create(): Client
    {
        $host = $this->elasticsearchConfig->getHost(); // https://search-{id}.{region}.es.amazonaws.com:443
        
        $handler = ClientBuilder::defaultHandler();
        
        // All requests to Elasticsearch in AWS must be signed
        if (StringUtility::contains($host, "amazonaws")) {
            $handler = $this->awsSignElasticsearch($handler);
        }
        
        return ClientBuilder::create()
            ->setHandler($handler)
            ->setLogger($this->logger)
            ->setTracer($this->logger)
            ->setHosts([ $host ])
            ->build();
    }
    
    /**
     * Creates an Elasticsearch HTTP handler with AWS signing
     *
     * @return callable
     */
    private function awsSignElasticsearch(callable $handler): callable
    {
        $awsCredentials = call_user_func($this->awsCredentialProvider)->wait();
        
        $middleware = new AwsSignatureMiddleware($awsCredentials, $this->awsSigner);
        $awsHandler = $middleware($handler);
        
        return $awsHandler;
    }
}
```

When using this middleware I get the exception `Undefined index: host` triggered at `AwsSignatureMiddleware.php:75`. I tried doing a `var_dump` of the return value of parsing the URL and got this:

```php
[
  "path" => "search-{id}.{region}.es.amazonaws.com"
]
```

This intends to fix that! Let me know if you need anything from me.

I also added the target PHP version to Composer, taken from your Travis tests. I prefer to look at that version in order to know which features from PHP I can use or not.